### PR TITLE
Update devbox setup to match server setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
 RUN echo 'deb http://ppa.launchpad.net/ansible/ansible/ubuntu focal main' > /etc/apt/sources.list.d/ansible.list \
  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 \
  && apt-get update \
- && apt-get install -y sudo ansible build-essential libmariadb-dev libmariadb-dev-compat libyaz-dev libnet-z3950-zoom-perl
+ && apt-get install -y sudo ansible build-essential libmariadb-dev libmariadb-dev-compat libyaz-dev libnet-z3950-zoom-perl libfribidi-dev
 
 RUN useradd -m -d /home/apps apps
 RUN echo 'apps ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/apps

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ sleep 30
 docker-compose -f docker-compose.yml -f docker-compose.build.yml up -d $KOHA_SERVICE
 
 docker-compose exec $KOHA_SERVICE koha-shell koha -c "$KOHA_HOME/misc/search_tools/rebuild_elasticsearch.pl -v -b"
+docker-compose exec $KOHA_SERVICE koha-shell koha -c "$KOHA_HOME/misc/search_tools/rebuild_elasticsearch.pl -v -a"
 
 sudo chown -R 1000 $MARIADB_DATADIR
 

--- a/devbox/hosts.yml
+++ b/devbox/hosts.yml
@@ -14,7 +14,7 @@ all:
       plack: false
       sip: false
       koha_home: "/home/{{ ansible_user }}/koha-repo"
-      koha_repo_version: "release-2022.02-20220310.1613"
+      koha_repo_version: "release-2022.02-20220517.1442"
       koha_po_files_path: "/home/{{ ansible_user }}/koha-repo/misc/translator/po"
       koha_instance_name: koha
       perl5lib_paths: "{{ koha_home }}/lib:{{ koha_home }}"
@@ -23,8 +23,24 @@ all:
       koha_db_host: "mariadb"
       koha_db_password: "{{ vault_koha_db_password }}"
       mariadb_root_password: "{{ vault_mariadb_root_password }}"
+      koha_ipac_api_key: "ipac-api-key"
+      get_print_data_api_key: "print-data-api-key"
+      koha_mojilicious_secret_passphrase: "verysecret"
       gobi_report_mail_to: david.gustafsson@ub.gu.se,g.katalog@ub.gu.se
       gobi_error_mail_to: david.gustafsson@ub.gu.se,g.katalog@ub.gu.se,stefan.berndtsson@ub.gu.se
       koha_online_payment_portal_url: https://betala-staging.ub.gu.se/Koha/Payment
       pip_install_packages:
         - name: PyMySQL
+      koha_data_dir: /mnt
+      mariadb_data_dir: /mnt/mariadb
+      elasticsearch_data_dir: /mnt/elasticsearch
+      # Mail settings
+      smtp_host: 127.0.0.1
+      smtp_port: 1025
+      smtp_username: ''
+      smtp_password: ''
+      smtp_ssl_mode: disabled
+      koha_database_backup_cron_enabled: false
+      gub_edifact_cron_enabled: false
+      edifact_cron_enabled: false
+      papercut_cron_enabled: false

--- a/koha-setup.yml
+++ b/koha-setup.yml
@@ -31,6 +31,12 @@
         regexp: '^(requires .Mojolicious::Plugin::OpenAPI., .)[\d\.]+(.;\s*)$'
         replace: "# \\1<= 3.39\\2"
 
+    - name: Limit version of Text::Bidi
+      ansible.builtin.replace:
+        path: "{{ koha_repo_path }}/cpanfile"
+        regexp: '^(requires .Text::Bidi., .)[\d\.]+(.;\s*)$'
+        replace: "# \\1<= 2.15\\2"
+
     - name: Limit version of JSON::Validator
       ansible.builtin.replace:
         path: "{{ koha_repo_path }}/cpanfile"


### PR DESCRIPTION
Some variables have been moved from default to host
Index authorities as well as biblios even though there are no authorities, so that the index is created
Add perl cpan changes to reflext newer release version